### PR TITLE
working  on ops

### DIFF
--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -40,9 +40,9 @@ jobs:
         if: contains(github.event.label.name, 'update-motd')
         run: |
           echo "Extracting MOTD from issue body..."
-          MOTD=$(echo "${{ github.event.issue.body }}" | sed -n 's/^### MOTD\n//p')
+          MOTD=$(echo "${{ github.event.issue.body }}" | awk '/^### MOTD/{getline; print}')
           if [ -z "$MOTD" ]; then
-            echo "Error: MOTD not found in issue body. Ensure the issue body contains the MOTD value."
+            echo "Error: MOTD not found in issue body. Ensure the issue body contains the MOTD value under '### MOTD'."
             exit 1
           fi
           echo "motd=$MOTD" >> $GITHUB_ENV


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/issue_ops.yml` file. The change updates the method of extracting the MOTD (Message of the Day) from the issue body by switching from `sed` to `awk` for better readability and reliability.

* [`.github/workflows/issue_ops.yml`](diffhunk://#diff-7349528d33fa2d6931e8f7c2a596b52eacab6f6d54356233e7f416291748c5b7L43-R45): Changed the command to extract MOTD from `sed` to `awk` and updated the error message to specify the expected format.