### PR TITLE
still working on extracton

### DIFF
--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -40,11 +40,12 @@ jobs:
         if: contains(github.event.label.name, 'update-motd')
         run: |
           echo "Extracting MOTD from issue body..."
-          MOTD=$(echo "${{ github.event.issue.body }}" | awk '/^### MOTD/{getline; print}')
+          MOTD=$(echo "${{ github.event.issue.body }}" | awk '/^### MOTD/{getline; gsub(/^[ \t]+|[ \t]+$/, ""); print}')
           if [ -z "$MOTD" ]; then
             echo "Error: MOTD not found in issue body. Ensure the issue body contains the MOTD value under '### MOTD'."
             exit 1
           fi
+          echo "Extracted MOTD: $MOTD"
           echo "motd=$MOTD" >> $GITHUB_ENV
 
       - name: Update MOTD using Pulumi CLI


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/issue_ops.yml` file. The change improves the extraction of the MOTD (Message of the Day) from the issue body by trimming leading and trailing whitespace from the extracted MOTD value.

* [`.github/workflows/issue_ops.yml`](diffhunk://#diff-7349528d33fa2d6931e8f7c2a596b52eacab6f6d54356233e7f416291748c5b7L43-R48): Modified the `awk` command to trim leading and trailing whitespace from the extracted MOTD value and added a debug echo statement to print the extracted MOTD.