### PR TITLE
changing motd template and issue logic

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-motd.yml
+++ b/.github/ISSUE_TEMPLATE/update-motd.yml
@@ -1,12 +1,13 @@
 name: Update MOTD
 description: Use this template to update the MOTD setting in Pulumi.dev.yaml
-title: "[Update MOTD] "
+title: "Update MOTD: <your-message>"
 labels: ["update-motd"]
 body:
   - type: markdown
     attributes:
       value: |
-        Please provide the new MOTD value below.
+        Please ensure the issue title follows this format: `Update MOTD: <your-message>`.
+        Replace `<your-message>` with the new MOTD value you want to set.
 
   - type: input
     id: motd

--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -35,14 +35,14 @@ jobs:
         run: |
           pulumi stack select dev
 
-      - name: Extract MOTD from Issue Body
+      - name: Extract MOTD from Issue Title
         id: extract-motd
         if: contains(github.event.label.name, 'update-motd')
         run: |
-          echo "Extracting MOTD from issue body..."
-          MOTD=$(echo "${{ github.event.issue.body }}" | awk '/^### MOTD/{getline; gsub(/^[ \t]+|[ \t]+$/, ""); print}')
+          echo "Extracting MOTD from issue title..."
+          MOTD=$(echo "${{ github.event.issue.title }}" | sed -n 's/^Update MOTD: //p')
           if [ -z "$MOTD" ]; then
-            echo "Error: MOTD not found in issue body. Ensure the issue body contains the MOTD value under '### MOTD'."
+            echo "Error: MOTD not found in issue title. Ensure the issue title starts with 'Update MOTD: '."
             exit 1
           fi
           echo "Extracted MOTD: $MOTD"


### PR DESCRIPTION
This pull request includes updates to the process for setting the Message of the Day (MOTD) in the Pulumi.dev.yaml configuration. The changes improve the clarity and reliability of extracting the MOTD from issue titles instead of issue bodies.

### Updates to MOTD setting process:

* [`.github/ISSUE_TEMPLATE/update-motd.yml`](diffhunk://#diff-c0c37991262954a4f6478306702f2e8e29c3a33723dc76e95e07541a07f9a7a5L3-R10): Modified the issue template to ensure the issue title follows the format `Update MOTD: <your-message>` and updated the instructions accordingly.
* [`.github/workflows/issue_ops.yml`](diffhunk://#diff-7349528d33fa2d6931e8f7c2a596b52eacab6f6d54356233e7f416291748c5b7L38-R45): Changed the workflow to extract the MOTD from the issue title instead of the issue body, ensuring the title starts with `Update MOTD: `.