### PR TITLE
testing new extraction

### DIFF
--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -40,9 +40,9 @@ jobs:
         if: contains(github.event.label.name, 'update-motd')
         run: |
           echo "Extracting MOTD from issue title..."
-          MOTD=$(echo "${{ github.event.issue.title }}" | sed -n 's/^Update MOTD: //p')
+          MOTD=$(echo "${{ github.event.issue.title }}" | sed -n 's/^Update MOTD: //p' | sed 's/^[ \t]*//;s/[ \t]*$//')
           if [ -z "$MOTD" ]; then
-            echo "Error: MOTD not found in issue title. Ensure the issue title starts with 'Update MOTD: '."
+            echo "Error: MOTD not found in issue title. Ensure the issue title starts with 'Update MOTD: ' and includes a message."
             exit 1
           fi
           echo "Extracted MOTD: $MOTD"


### PR DESCRIPTION
This pull request includes an improvement to the `jobs:` section in the `.github/workflows/issue_ops.yml` file. The change enhances the extraction of the Message of the Day (MOTD) from the issue title by trimming leading and trailing whitespace.

* [`.github/workflows/issue_ops.yml`](diffhunk://#diff-7349528d33fa2d6931e8f7c2a596b52eacab6f6d54356233e7f416291748c5b7L43-R45): Modified the `MOTD` extraction command to trim leading and trailing whitespace from the issue title.