### PR TITLE
one more go

### DIFF
--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -58,15 +58,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Updating MOTD using Pulumi CLI..."
-          echo "MOTD: $MOTD"
-          pulumi config set pulumi_ts:motd "$MOTD" --cwd .
+          echo "MOTD: ${{ env.motd }}"
+          pulumi config set pulumi_ts:motd "${{ env.motd }}" --cwd .
           echo "Contents of Pulumi.dev.yaml after pulumi config set:"
           cat Pulumi.dev.yaml
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
           git add Pulumi.dev.yaml
-          git commit -m "Update MOTD to $MOTD"
+          git commit -m "Update MOTD to ${{ env.motd }}"
           git push
 
       - name: Trigger Push Workflow


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/issue_ops.yml` file. The change updates the way the `MOTD` environment variable is referenced and used within the workflow.

Workflow updates:

* [`.github/workflows/issue_ops.yml`](diffhunk://#diff-7349528d33fa2d6931e8f7c2a596b52eacab6f6d54356233e7f416291748c5b7L61-R69): Modified the script to use `${{ env.motd }}` instead of `$MOTD` for setting and committing the `motd` configuration in Pulumi.